### PR TITLE
Подготовка графики личного проекта

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -3,14 +3,14 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Техномарт - Главная</title>
+  <title>Техномарт - Перфораторы</title>
 </head>
 
 <body>
   <header class="main-header">
     <section class="top-bar">
       <div class="container">
-        <a class="logo" href="#">ТЕХНОМАРТ</a>
+        <a class="logo" href="index.html"><img src="img/logo.svg" width="110" height="17" alt="Техномарт"></a>
         <div class="search-form">Поиск:</div>
         <ul class="top-user-menu">
           <li class="bookmarks"><a href="#">Закладки: <span>0</span></a></li>
@@ -150,7 +150,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 3000</h3>
               <p class="old-price">
                 22500 Р.
@@ -164,7 +164,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 6000</h3>
               <p class="old-price">
                 30500 Р.
@@ -178,7 +178,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 2000</h3>
               <p class="new-price">
                 12500 Р.
@@ -189,7 +189,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 3000</h3>
               <p class="old-price">
                 22500 Р.
@@ -203,7 +203,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 6000</h3>
               <p class="old-price">
                 30500 Р.
@@ -217,7 +217,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 2000</h3>
               <p class="new-price">
                 12500 Р.
@@ -228,7 +228,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 3000</h3>
               <p class="old-price">
                 22500 Р.
@@ -242,7 +242,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 6000</h3>
               <p class="old-price">
                 30500 Р.
@@ -256,7 +256,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="catalog-item-img"><img src="/img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 2000</h3>
               <p class="new-price">
                 12500 Р.
@@ -299,7 +299,7 @@
     <section class="footer-nav">
       <div class="container">
         <div class="footer-brand-container">
-          <a class="footer-logo" href="#">ТЕХНОМАРТ</a>
+          <a class="footer-logo" href="#"><img src="img/logo.svg" width="138" height="21" alt="Техномарт"></a>
           <address class="footer-address">
             г. Санкт-Петербург, ул. Б. Конюшенная, д. 19/8 <br> +7 (812) 555-05-55
           </address>

--- a/catalog.html
+++ b/catalog.html
@@ -150,7 +150,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 3000</h3>
               <p class="old-price">
                 22500 Р.
@@ -164,7 +164,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 6000</h3>
               <p class="old-price">
                 30500 Р.
@@ -178,7 +178,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 2000</h3>
               <p class="new-price">
                 12500 Р.
@@ -189,7 +189,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 3000</h3>
               <p class="old-price">
                 22500 Р.
@@ -203,7 +203,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 6000</h3>
               <p class="old-price">
                 30500 Р.
@@ -217,7 +217,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 2000</h3>
               <p class="new-price">
                 12500 Р.
@@ -228,7 +228,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 3000</h3>
               <p class="old-price">
                 22500 Р.
@@ -242,7 +242,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 6000</h3>
               <p class="old-price">
                 30500 Р.
@@ -256,7 +256,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="catalog-item-img"><img src="/img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
+              <figure class="catalog-item-img"><img src="img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
               <h3 class="catalog-item-title">Перфоратор BOSCH BFG 2000</h3>
               <p class="new-price">
                 12500 Р.

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <header class="main-header">
     <section class="top-bar">
       <div class="container">
-        <a class="logo">ТЕХНОМАРТ</a>
+        <a class="logo"><img src="img/logo.svg" width="110" height="17" alt="Техномарт"></a>
         <div class="search-form">Поиск:</div>
         <ul class="top-user-menu">
           <li class="bookmarks"><a href="#">Закладки: <span>0</span></a></li>
@@ -96,7 +96,7 @@
               <div class="slides">
                 <div class="slide">
                   <figure class="slide-img">
-                    <img src="http://placehold.it/620x266" width="620" height="266" alt="Перфораторы">
+                    <img src="img/banner1.jpg" width="620" height="266" alt="Перфораторы">
                   </figure>
                   <div class="slide-text">
                     <h3 class="slide-title">Перфораторы</h3>
@@ -108,7 +108,7 @@
                 </div>
                 <div class="slide">
                   <figure class="slide-img">
-                    <img src="http://placehold.it/620x266" width="620" height="266" alt="Дрели">
+                    <img src="img/banner2.jpg" width="620" height="266" alt="Дрели">
                   </figure>
                   <div class="slide-text">
                     <h3 class="slide-title">Дрели</h3>
@@ -149,7 +149,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="popular-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="popular-item-img"><img src="img/bfg9000.png" width="218" alt="Перфоратор BOSCH BFG 9000"></figure>
               <h3 class="popular-item-title">Перфоратор BOSCH BFG 9000</h3>
               <p class="old-price">
                 32500 Р.
@@ -163,7 +163,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="popular-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="popular-item-img"><img src="img/bfg3000.png" width="218" alt="Перфоратор BOSCH BFG 3000"></figure>
               <h3 class="popular-item-title">Перфоратор BOSCH BFG 3000</h3>
               <p class="old-price">
                 22500 Р.
@@ -177,7 +177,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="popular-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="popular-item-img"><img src="img/bfg6000.png" width="218" alt="Перфоратор BOSCH BFG 6000"></figure>
               <h3 class="popular-item-title">Перфоратор BOSCH BFG 6000</h3>
               <p class="old-price">
                 30500 Р.
@@ -191,7 +191,7 @@
                 <a class="buy" href="#">Купить</a>
                 <a class="bookmark" href="#">В закладки</a>
               </div>
-              <figure class="popular-item-img"><img src="http://placehold.it/218x165" width="218" height="165" alt="product-photo"></figure>
+              <figure class="popular-item-img"><img src="img/bfg2000.png" width="218" alt="Перфоратор BOSCH BFG 2000"></figure>
               <h3 class="popular-item-title">Перфоратор BOSCH BFG 2000</h3>
               <p class="new-price">
                 12500 Р.
@@ -206,28 +206,28 @@
           </header>
           <ul class="popular-brands">
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-bosch.png" alt="Bosch"></a>
             </li>
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-makita.png" alt="Makita"></a>
             </li>
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-dewalt.png" alt="DeWALT"></a>
             </li>
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-interskol.png" alt="Интерскол"></a>
             </li>
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-hitachi.png" alt="Hitachi"></a>
             </li>
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-lg.png" alt="LG"></a>
             </li>
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-aeg.png" alt="AEG"></a>
             </li>
             <li class="brand-item">
-              <a href="#"><img src="http://placehold.it/218x143" alt="Логотип производителя"></a>
+              <a href="#"><img src="img/logo-metabo.png" alt="Metabo"></a>
             </li>
           </ul>
         </div>
@@ -298,7 +298,7 @@
           <h2 class="section-title">Контакты</h2>
           <p class="about-text">Вы можете забрать товар сами, заехав в наш офис:</p>
           <a class="contacts-map" href="#">
-            <img src="http://placehold.it/300x158" width="300" height="158" alt="Карта проезда">
+            <img src="img/map-mini.png" width="300" height="158" alt="Открыть карту проезда">
           </a>
           <a class="write-us" href="#">Напишите нам!</a>
         </div>
@@ -309,6 +309,7 @@
   <section class="modal-map">
     <h2 class="visually-hidden">Как до нас добраться</h2>
     <button class="modal-close">Закрыть</button>
+    <img src="img/map-popup.png" width="940" height="446" alt="Карта проезда">
   </section>
 
   <section class="modal-write-us">
@@ -321,7 +322,7 @@
     <section class="footer-nav">
       <div class="container">
         <div class="footer-brand-container">
-          <a class="footer-logo">ТЕХНОМАРТ</a>
+          <a class="footer-logo"><img src="img/logo.svg" width="138" height="21" alt="Техномарт"></a>
           <address class="footer-address">
             г. Санкт-Петербург, ул. Б. Конюшенная, д. 19/8 <br> +7 (812) 555-05-55
           </address>


### PR DESCRIPTION
Размеры картинок блока популярных товаров и каталога указаны в теге только по ширине, т.к. соотношение сторон в использовании реального проекта никто контролировать не будет.
Размеры логотипов производителей в тегах не указаны вообще по похожей причине (хотя в случае с логотипами можно и стандартизацию произвести).

---
:mortar_board: [Подготовка графики личного проекта](https://up.htmlacademy.ru/htmlcss/21/user/19362/tasks/20)